### PR TITLE
changed shebang

### DIFF
--- a/core/casting.py
+++ b/core/casting.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import collections

--- a/core/defaults.py
+++ b/core/defaults.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 config_defaults = {

--- a/core/fancy_logs.py
+++ b/core/fancy_logs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import sys

--- a/core/main.py
+++ b/core/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import sys

--- a/core/parse_conf.py
+++ b/core/parse_conf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import configparser

--- a/core/plugin_base.py
+++ b/core/plugin_base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 log = None

--- a/plugins/web/__init__.py
+++ b/plugins/web/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from . import header

--- a/plugins/web/base.py
+++ b/plugins/web/base.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import core.plugin_base

--- a/plugins/web/core_events.py
+++ b/plugins/web/core_events.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import core.plugin_base

--- a/plugins/web/header.py
+++ b/plugins/web/header.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import core.plugin_base

--- a/plugins/web/request_events.py
+++ b/plugins/web/request_events.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import core.plugin_base

--- a/plugins/web/tests/plugins/debug_web.py
+++ b/plugins/web/tests/plugins/debug_web.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import core.plugin_base

--- a/plugins/web/tests/test_web.py
+++ b/plugins/web/tests/test_web.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import pytest

--- a/pythapi.py
+++ b/pythapi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import signal

--- a/tests/plugins/broken.py
+++ b/tests/plugins/broken.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import core.plugin_base

--- a/tests/plugins/broken_check.py
+++ b/tests/plugins/broken_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import core.plugin_base

--- a/tests/plugins/broken_load.py
+++ b/tests/plugins/broken_load.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import core.plugin_base

--- a/tests/plugins/broken_loop.py
+++ b/tests/plugins/broken_loop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import core.plugin_base

--- a/tests/plugins/debug.py
+++ b/tests/plugins/debug.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import core.plugin_base

--- a/tests/plugins/debug2.py
+++ b/tests/plugins/debug2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import core.plugin_base

--- a/tests/plugins/debug3.py
+++ b/tests/plugins/debug3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import core.plugin_base

--- a/tests/test_casting.py
+++ b/tests/test_casting.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import pytest

--- a/tests/test_fancy_logs.py
+++ b/tests/test_fancy_logs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import pytest

--- a/tests/test_parse_conf.py
+++ b/tests/test_parse_conf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import pytest


### PR DESCRIPTION
The new shebang uses the python3 executable from current path.
Without this, plugins couldn't import modules from a virtualenv.